### PR TITLE
Remove inline section dropdowns and add navbar menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Changelog
 
 ### Unreleased
+- Added performance sections dropdown in navbar and removed inline dropdown blocks from policy pages.
 - Created `REVAMP` branch from `work` to continue UI/UX revamp tasks.
 - Added responsive DaisyUI navbar with Tailwind and Alpine.js; active page now highlighted via context.
 - Cleaned up `README.md` by removing shell prompt artifacts and adding missing license closing text.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -44,3 +44,4 @@
 - [x] Frozen-Flask wrote pages without `.html` extensions causing markdown-like display; patched freezer and added build tests.
 - [x] Inconsistent typography across templates; applied Tailwind heading classes and DaisyUI prose sections.
 
+- [x] Integrated Sections dropdown; removed duplicated dropdown blocks from policy pages.

--- a/TODO_nav.md
+++ b/TODO_nav.md
@@ -35,3 +35,4 @@
 - [x] **Menu Polish**: Added rounded borders, centered layout, and hover highlights on all navigation buttons.
 - [x] **Menu Spacing**: Added gaps and hover scaling for buttons; stacked theme toggle above language switcher.
 
+- [x] Added "Sections" dropdown menu for performance pages.

--- a/templates/base.html
+++ b/templates/base.html
@@ -209,12 +209,12 @@
 
             <!-- desktop menu -->
             <ul class="menu menu-horizontal gap-3 p-1 hidden md:flex mx-auto border border-base-300 rounded-box bg-base-100 mx-4" role="menu">
-                <li class="mx-1"><a href="{{ url_for('home') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='home' %}active{% endif %}" role="menuitem" data-i18n="nav.home">Accueil</a></li>
-                <li class="mx-1"><a href="{{ url_for('politique') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='politique' %}active{% endif %}" role="menuitem" data-i18n="nav.politique">Politique d’intégration</a></li>
-                <li class="mx-1"><a href="{{ url_for('performance_index') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='performance' %}active{% endif %}" role="menuitem" data-i18n="nav.performance">Politique de performance</a></li>
-                <li class="mx-1"><a href="{{ url_for('contact') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='contact' %}active{% endif %}" role="menuitem" data-i18n="nav.contact">Contact RH</a></li>
-                <li class="mx-1"><a href="{{ url_for('coulisses') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='coulisses' %}active{% endif %}" role="menuitem" data-i18n="nav.coulisses">Les Coulisses</a></li>
-                <li class="mx-1"><a href="{{ url_for('rh_chatbot') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='rh_chatbot' %}active{% endif %}" role="menuitem" data-i18n="nav.chatbot">Demandez aux RH</a></li>
+                <li class="mx-1" @click="open=false"><a href="{{ url_for('home') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='home' %}active{% endif %}" role="menuitem" data-i18n="nav.home">Accueil</a></li>
+                <li class="mx-1" @click="open=false"><a href="{{ url_for('politique') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='politique' %}active{% endif %}" role="menuitem" data-i18n="nav.politique">Politique d’intégration</a></li>
+                <li class="mx-1" @click="open=false"><a href="{{ url_for('performance_index') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='performance' %}active{% endif %}" role="menuitem" data-i18n="nav.performance">Politique de performance</a></li>
+                <li class="mx-1" @click="open=false"><a href="{{ url_for('contact') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='contact' %}active{% endif %}" role="menuitem" data-i18n="nav.contact">Contact RH</a></li>
+                <li class="mx-1" @click="open=false"><a href="{{ url_for('coulisses') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='coulisses' %}active{% endif %}" role="menuitem" data-i18n="nav.coulisses">Les Coulisses</a></li>
+                <li class="mx-1" @click="open=false"><a href="{{ url_for('rh_chatbot') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='rh_chatbot' %}active{% endif %}" role="menuitem" data-i18n="nav.chatbot">Demandez aux RH</a></li>
             </ul>
 
             <div class="flex flex-col items-center ml-2 space-y-1">
@@ -233,13 +233,31 @@
         <!-- mobile dropdown -->
         <ul class="menu menu-compact space-y-1 mt-2 w-full md:hidden border border-base-300 rounded-box bg-base-100"
             x-show="open" x-transition.opacity.duration.200ms x-cloak
-            @click="open=false" role="menu">
-            <li class="mx-1"><a href="{{ url_for('home') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='home' %}active{% endif %}" data-i18n="nav.home">Accueil</a></li>
-            <li class="mx-1"><a href="{{ url_for('politique') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='politique' %}active{% endif %}" data-i18n="nav.politique">Politique d’intégration</a></li>
-            <li class="mx-1"><a href="{{ url_for('performance_index') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='performance' %}active{% endif %}" data-i18n="nav.performance">Politique de performance</a></li>
-            <li class="mx-1"><a href="{{ url_for('contact') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='contact' %}active{% endif %}" data-i18n="nav.contact">Contact RH</a></li>
-            <li class="mx-1"><a href="{{ url_for('coulisses') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='coulisses' %}active{% endif %}" data-i18n="nav.coulisses">Les Coulisses</a></li>
-            <li class="mx-1"><a href="{{ url_for('rh_chatbot') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='rh_chatbot' %}active{% endif %}" data-i18n="nav.chatbot">Demandez aux RH</a></li>
+            role="menu">
+            <li class="mx-1" @click="open=false"><a href="{{ url_for('home') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='home' %}active{% endif %}" data-i18n="nav.home">Accueil</a></li>
+            <li class="mx-1" @click="open=false"><a href="{{ url_for('politique') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='politique' %}active{% endif %}" data-i18n="nav.politique">Politique d’intégration</a></li>
+            <li class="mx-1" @click="open=false"><a href="{{ url_for('performance_index') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='performance' %}active{% endif %}" data-i18n="nav.performance">Politique de performance</a></li>
+            {% if active_page == 'performance' %}
+            <li class="mx-1">
+                <div class="dropdown w-full">
+                    <label tabindex="0" class="btn btn-ghost w-full text-left rounded-lg hover:bg-base-200 transition ease-in duration-150" @click.stop>Sections ▾</label>
+                    <ul x-show="open" tabindex="0" class="dropdown-content z-50 menu p-2 shadow bg-base-100 rounded-box w-52 transition ease-in duration-150">
+                        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}" @click="open=false">Phase&nbsp;1 – Semis</a></li>
+                        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}" @click="open=false">Phase&nbsp;2 – Croissance</a></li>
+                        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}" @click="open=false">Phase&nbsp;3 – Récolte</a></li>
+                        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}" @click="open=false">Phase&nbsp;4 – Renouvellement</a></li>
+                        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}" @click="open=false">Acteurs clés et responsabilités</a></li>
+                        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}" @click="open=false">Conclusion</a></li>
+                        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}" @click="open=false">Glossaire</a></li>
+                        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}" @click="open=false">Bibliographie</a></li>
+                        <li><a href="{{ url_for('performance_section', section='09_resume') }}" @click="open=false">Résumé de correction</a></li>
+                    </ul>
+                </div>
+            </li>
+            {% endif %}
+            <li class="mx-1" @click="open=false"><a href="{{ url_for('contact') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='contact' %}active{% endif %}" data-i18n="nav.contact">Contact RH</a></li>
+            <li class="mx-1" @click="open=false"><a href="{{ url_for('coulisses') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='coulisses' %}active{% endif %}" data-i18n="nav.coulisses">Les Coulisses</a></li>
+            <li class="mx-1" @click="open=false"><a href="{{ url_for('rh_chatbot') }}" class="btn btn-ghost w-full text-left hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='rh_chatbot' %}active{% endif %}" data-i18n="nav.chatbot">Demandez aux RH</a></li>
         </ul>
     </nav>
 

--- a/templates/performance_policy/01_phase1_semis.html
+++ b/templates/performance_policy/01_phase1_semis.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Phase 1 – Semis : Définir, ancrer, aligner</h1>
 <img src="{{ url_for('serve_assets', filename='NEW_Images/phase1_semis_nourrir.png') }}"
      alt="Phase 1 Semis" class="w-full max-w-md mx-auto rounded-lg md:float-right md:ml-6 mb-4 fade-section">

--- a/templates/performance_policy/02_phase2_croissance.html
+++ b/templates/performance_policy/02_phase2_croissance.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Phase 2 – Croissance : Suivre, ajuster, faire fleurir</h1>
 <img src="{{ url_for('serve_assets', filename='NEW_Images/phase2_croissance_nourrir.png') }}"
      alt="Phase 2 Croissance" class="w-full max-w-md mx-auto rounded-lg md:float-left md:mr-6 mb-4 fade-section">

--- a/templates/performance_policy/03_phase3_recolte.html
+++ b/templates/performance_policy/03_phase3_recolte.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Phase 3 – Récolte : Reconnaître, célébrer, projeter</h1>
 <img src="{{ url_for('serve_assets', filename='NEW_Images/phase3_recolte_nourrir.png') }}"
      alt="Phase 3 Récolte" class="w-full max-w-md mx-auto rounded-lg md:float-right md:ml-6 mb-4 fade-section">

--- a/templates/performance_policy/04_phase4_renouvellement.html
+++ b/templates/performance_policy/04_phase4_renouvellement.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Phase 4 – Renouvellement : Apprendre, évoluer, transformer</h1>
 <img src="{{ url_for('serve_assets', filename='NEW_Images/phase4_renouvellement_nourrir.png') }}"
      alt="Phase 4 Renouvellement" class="w-full max-w-md mx-auto rounded-lg md:float-left md:mr-6 mb-4 fade-section">

--- a/templates/performance_policy/05_roles_responsabilites.html
+++ b/templates/performance_policy/05_roles_responsabilites.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Acteurs clés et responsabilités dans le cycle</h1>
 <p><strong>Légende RACI</strong></p>
 <ul>

--- a/templates/performance_policy/06_conclusion.html
+++ b/templates/performance_policy/06_conclusion.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Conclusion</h1>
 <p>Chez NourrIR, la gestion de la performance est un cycle vivant et engageant, qui met en dialogue les aspirations individuelles, les besoins de l’organisation et les possibilités offertes par la technologie. Elle favorise un climat de responsabilité partagée, de reconnaissance sincère et de développement continu. Ici, l’évaluation n’est jamais une fin : elle est un engrais pour la prochaine saison.</p>
 </section>

--- a/templates/performance_policy/07_glossaire.html
+++ b/templates/performance_policy/07_glossaire.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Glossaire des termes et acronymes</h1>
 <table>
 <tr><th>Terme / acronyme</th><th>Définition</th></tr>

--- a/templates/performance_policy/08_bibliographie.html
+++ b/templates/performance_policy/08_bibliographie.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Bibliographie</h1>
 <ul>
 <li>► Outils IA utilisé : ChatGPT</li>

--- a/templates/performance_policy/09_resume.html
+++ b/templates/performance_policy/09_resume.html
@@ -3,20 +3,6 @@
 {% block content %}
 <section class="p-6 my-8 rounded-lg shadow-md bg-base-200 prose max-w-none fade-section">
 <p><a href="{{ url_for('performance_index') }}" class="back-button" aria-label="Retour à l'index">&#8592;<span class="back-text"> Retour à l'index</span></a></p>
-<details class="section-dropdown">
-    <summary>Accéder aux sections</summary>
-    <ul>
-        <li><a href="{{ url_for('performance_section', section='01_phase1_semis') }}">Phase&nbsp;1 – Semis</a></li>
-        <li><a href="{{ url_for('performance_section', section='02_phase2_croissance') }}">Phase&nbsp;2 – Croissance</a></li>
-        <li><a href="{{ url_for('performance_section', section='03_phase3_recolte') }}">Phase&nbsp;3 – Récolte</a></li>
-        <li><a href="{{ url_for('performance_section', section='04_phase4_renouvellement') }}">Phase&nbsp;4 – Renouvellement</a></li>
-        <li><a href="{{ url_for('performance_section', section='05_roles_responsabilites') }}">Acteurs clés et responsabilités</a></li>
-        <li><a href="{{ url_for('performance_section', section='06_conclusion') }}">Conclusion</a></li>
-        <li><a href="{{ url_for('performance_section', section='07_glossaire') }}">Glossaire</a></li>
-        <li><a href="{{ url_for('performance_section', section='08_bibliographie') }}">Bibliographie</a></li>
-        <li><a href="{{ url_for('performance_section', section='09_resume') }}">Résumé de correction</a></li>
-    </ul>
-</details>
 <h1>Résumé de correction</h1>
 <p>Ce document présente le processus de gestion de la performance de l’entreprise fictive NourrIR, conçu dans le cadre d’un travail universitaire. Il répond aux exigences pédagogiques du cours en intégrant les éléments fondamentaux attendus dans un cadre de gestion moderne et humaniste de la performance. La structure du processus est articulée autour d’un cycle en quatre phases (semis, croissance, récolte, renouvellement), à l’image des saisons, reflétant la nature vivante, évolutive et continue de la performance en milieu de travail.</p>
 <p>L’approche adoptée répond rigoureusement aux critères suivants :</p>


### PR DESCRIPTION
## Summary
- remove details dropdowns from performance policy templates
- add Sections dropdown navigation in base template
- keep mobile menu state in sync with hamburger toggle
- document dropdown work in TODO, changelog, and issues log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685321af25ec83239b0515649c3fe9d1