### PR TITLE
Update theme toggle to button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Improved spacing for navbar buttons and grouped theme toggle with language switcher.
 - Fixed dark/light toggle regression and polished menu styles with rounded borders and hover highlights.
 - Spaced out menu buttons further with hover scaling; theme toggle icons display side-by-side above language switcher and brand text hides on scroll.
+- Replaced checkbox theme switch with an accessible button that toggles `aria-pressed` and swaps sun/moon icons without layout shift.
 - Fixed static build producing extensionless pages; patched freezer to write `index.html` files and added tests checking for markdown.
 - Replaced custom section and footer CSS with DaisyUI classes; unified heading styles across templates and removed unused rules.
 

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -26,8 +26,9 @@
 - [x] Duplicate Docker commands in README created confusion; removed extra build/run lines.
 - [x] Tests failed when the `build/` directory was missing. Added an autouse fixture to generate the static site before tests.
 - [ ] Verify DaisyUI navbar works consistently across browsers.
- - [x] Ensure new theme toggle functions across browsers and persists across sessions.
- - [x] Navigation menu lacked hover highlight and rounded borders; centered menu and added hover styles.
+- [x] Ensure new theme toggle functions across browsers and persists across sessions.
+- [ ] Confirm accessible theme button sets `aria-pressed` correctly and swaps icons without causing layout shift.
+- [x] Navigation menu lacked hover highlight and rounded borders; centered menu and added hover styles.
 - [ ] Expand translations to remaining pages and content.
 - [x] Old page-specific CSS made maintenance difficult; migrated to Tailwind utility classes and DaisyUI components.
 - [ ] Verify mobile behavior of new tooltips.

--- a/TODO_nav.md
+++ b/TODO_nav.md
@@ -34,5 +34,6 @@
 - [x] **Netlify Routing Check**: Confirm nav `href` values match existing routes (`/`, `/politique`, `/performance`, `/contact`) with no URL changes.
 - [x] **Menu Polish**: Added rounded borders, centered layout, and hover highlights on all navigation buttons.
 - [x] **Menu Spacing**: Added gaps and hover scaling for buttons; stacked theme toggle above language switcher.
+- [x] **Toggle Button Layout**: Theme switch now appears as a button before the language selector.
 
 - [x] Added "Sections" dropdown menu for performance pages.

--- a/TODO_theme.md
+++ b/TODO_theme.md
@@ -27,7 +27,9 @@
 - [x] **Persist on Reload**: Test that theme preference persists after page refresh and reloading the site.
 - [x] **Fix Regression**: Theme toggle stopped switching modes; bound `true-value` and `false-value` via `x-bind` to restore functionality.
 
- - [x] **System Prefers Dark (optional)**: Detect `window.matchMedia('(prefers-color-scheme: dark)')` to set default theme on first load if no localStorage value.
+- [x] **System Prefers Dark (optional)**: Detect `window.matchMedia('(prefers-color-scheme: dark)')` to set default theme on first load if no localStorage value.
+
+- [x] **Replace Checkbox with Button**: Use `<button id="theme-toggle">` with accessible `aria-pressed` state and inline SVG icons.
 
  - [ ] **Test Styling in Both Modes**: Manually verify UI components switch correctly in light and dark modes.
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -217,12 +217,20 @@
                 <li class="mx-1" @click="open=false"><a href="{{ url_for('rh_chatbot') }}" class="btn btn-ghost hover:bg-base-200 rounded-lg transition-transform duration-150 hover:scale-105 {% if active_page=='rh_chatbot' %}active{% endif %}" role="menuitem" data-i18n="nav.chatbot">Demandez aux RH</a></li>
             </ul>
 
-            <div class="flex flex-col items-center ml-2 space-y-1">
-                <label class="flex items-center gap-1 cursor-pointer">
-                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
-                    <input type="checkbox" class="toggle theme-controller" x-model="theme" :true-value="'dark'" :false-value="'light'" @change="theme = $el.checked ? 'dark' : 'light'">
-                    <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-                </label>
+            <div class="flex items-center ml-2 gap-2">
+                <button id="theme-toggle" aria-pressed="false" aria-label="Switch between light and dark theme"
+                        class="btn btn-ghost"
+                        x-init="$el.setAttribute('aria-pressed', theme === 'dark')"
+                        @click="theme = theme === 'light' ? 'dark' : 'light'; $el.setAttribute('aria-pressed', theme === 'dark')">
+                    <span class="relative w-5 h-5 block">
+                        <svg x-show="theme === 'light'" class="absolute inset-0 w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                        </svg>
+                        <svg x-show="theme === 'dark'" class="absolute inset-0 w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+                        </svg>
+                    </span>
+                </button>
                 <div class="flex space-x-1">
                     <button class="btn btn-ghost btn-sm" onclick="switchLang('fr')">FR</button>
                     <button class="btn btn-ghost btn-sm" onclick="switchLang('en')">EN</button>


### PR DESCRIPTION
## Summary
- switch theme toggle from checkbox to `<button id="theme-toggle">`
- add Alpine logic that updates `aria-pressed`
- place the button before the language switcher in the navbar
- document the change in TODOs and changelog
- log new issue for accessible button

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68532fc644348323990e472637f2e8fd