### PR TITLE
Add Playwright integration tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,10 +17,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
+          playwright install --with-deps
 
       - name: Freeze site
         run: python freeze.py
 
       - name: Run smoke tests
-        run: pytest tests
+        run: |
+          python -m http.server 8000 -d build &
+          pytest tests --headed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,4 @@
 - Added `.gitignore` to exclude Python artifacts and environment files.
 - Removed committed `__pycache__/` directory from version control.
 
+- Added Playwright integration tests and updated CI to run them in headed mode.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -49,3 +49,4 @@
 - [x] Integrated Sections dropdown; removed duplicated dropdown blocks from policy pages.
 - [x] Moved fade-section observer into `static/js/ui.js` with navbar sentinel logic; base template references the new script.
 - [x] Replaced `@scroll.window` listener with custom `sentinel-change` event; navbar opacity toggles via IntersectionObserver.
+- [x] Added Playwright tests for theme toggle, navbar transparency and mobile menu.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gunicorn
 serverless-wsgi
 pytest>=7.0
 Frozen-Flask>=1
+pytest-playwright>=0.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 # Ensure the project root is in PYTHONPATH so we can import freeze.py
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from freeze import freezer
+import subprocess
+import time
 
 @pytest.fixture(scope="session", autouse=True)
 def ensure_build():
@@ -13,3 +15,22 @@ def ensure_build():
         import shutil
         shutil.rmtree("build")
     freezer.freeze()
+
+
+@pytest.fixture(scope="session")
+def server(ensure_build):
+    """Serve the built site for browser-based tests."""
+    proc = subprocess.Popen([sys.executable, "-m", "http.server", "8000", "-d", "build"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(1)
+    yield "http://localhost:8000"
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()
+
+
+@pytest.fixture
+def adopt(page):
+    """Alias Playwright's page fixture to match roadmap instructions."""
+    return page

--- a/tests/test_mobile_menu.py
+++ b/tests/test_mobile_menu.py
@@ -1,0 +1,12 @@
+import pytest
+
+@pytest.mark.playwright
+def test_mobile_menu_toggle(adopt, server):
+    page = adopt
+    page.set_viewport_size({'width': 375, 'height': 640})
+    page.goto(server)
+    menu = page.locator('ul.menu-compact')
+    assert not menu.is_visible()
+    page.click('button[aria-label="Toggle navigation"]')
+    page.wait_for_timeout(200)
+    assert menu.is_visible()

--- a/tests/test_nav_dropdown.py
+++ b/tests/test_nav_dropdown.py
@@ -1,0 +1,11 @@
+import pytest
+
+@pytest.mark.playwright
+def test_performance_sections_dropdown(adopt, server):
+    page = adopt
+    page.goto(f"{server}/performance")
+    label = page.locator('label', has_text='Sections')
+    label.click()
+    dropdown = page.locator('ul.dropdown-content')
+    dropdown.wait_for(state='visible')
+    assert dropdown.locator('a', has_text='Phase').count() > 0

--- a/tests/test_nav_padding.py
+++ b/tests/test_nav_padding.py
@@ -1,0 +1,13 @@
+import pytest
+
+@pytest.mark.playwright
+def test_navbar_padding_changes_on_scroll(adopt, server):
+    page = adopt
+    page.goto(server)
+    nav = page.locator('nav')
+    cls = nav.get_attribute('class')
+    assert 'py-6' in cls
+    page.evaluate('window.scrollTo(0, 600)')
+    page.wait_for_timeout(300)
+    cls_after = nav.get_attribute('class')
+    assert 'py-2' in cls_after

--- a/tests/test_navbar_transparency.py
+++ b/tests/test_navbar_transparency.py
@@ -1,0 +1,11 @@
+import pytest
+
+@pytest.mark.playwright
+def test_navbar_transparency(adopt, server):
+    page = adopt
+    page.goto(server)
+    nav = page.locator('nav')
+    assert 'bg-opacity-90' not in nav.get_attribute('class')
+    page.evaluate('window.scrollTo(0, 600)')
+    page.wait_for_timeout(300)
+    assert 'bg-opacity-90' in nav.get_attribute('class')

--- a/tests/test_theme_toggle.py
+++ b/tests/test_theme_toggle.py
@@ -1,0 +1,15 @@
+import pytest
+
+@pytest.mark.playwright
+def test_theme_toggle_persists(adopt, server):
+    page = adopt
+    page.goto(server)
+    html = page.locator('html')
+    initial = html.get_attribute('data-theme') or 'light'
+    page.click('#theme-toggle')
+    page.wait_for_timeout(200)
+    toggled = html.get_attribute('data-theme')
+    assert toggled and toggled != initial
+    page.reload()
+    page.wait_for_load_state('networkidle')
+    assert html.get_attribute('data-theme') == toggled


### PR DESCRIPTION
## Summary
- add pytest-playwright to requirements
- create Playwright browser tests for navbar behavior and theme toggle
- serve build folder in tests via new `server` fixture
- update CI workflow to install browsers and run tests in headed mode
- log new work in changelog and issues log

## Testing
- `playwright install chromium`
- `pytest -q` *(fails: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_685342b0c22c832384a262a7ead49056