### PR TITLE
Document navbar sentinel fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Added Netlify deployment files and documentation.
 - Integrated performance policy visuals from `NEW_Images` with fade-in transitions and alternating layout.
 - Switched navbar opacity logic to an IntersectionObserver watching `#top-sentinel` and removed the body scroll handler.
+- Ensured the IntersectionObserver fires by giving `#top-sentinel` a 1px height,
+  preventing the navbar from staying fully transparent.
 - Fixed incorrect asset paths and gave images rounded corners; added tests ensuring `NEW_Images` load correctly.
 - Added phase navigation buttons on the performance index and fade-out transitions for scrollable sections.
 - Fixed trailing prompt artifact in `test.py`.

--- a/ISSUES_LOG.md
+++ b/ISSUES_LOG.md
@@ -49,6 +49,9 @@
 - [x] Integrated Sections dropdown; removed duplicated dropdown blocks from policy pages.
 - [x] Moved fade-section observer into `static/js/ui.js` with navbar sentinel logic; base template references the new script.
 - [x] Replaced `@scroll.window` listener with custom `sentinel-change` event; navbar opacity toggles via IntersectionObserver.
+- [x] Navbar remained fully transparent because the IntersectionObserver never
+  detected the top sentinel. Added a 1px `#top-sentinel` element so the
+  observer fires correctly and the navbar gains opacity after scrolling.
 - [x] Added Playwright tests for theme toggle, navbar transparency and mobile menu.
 - [x] Initialized theme early with inline script and `ui.js` click handler; toggle now sets `aria-pressed` and persists choice.
 - [x] DaisyUI classes missing from compiled CSS; created `input.css` and updated Tailwind config to use the plugin's default export.

--- a/flask.py
+++ b/flask.py
@@ -173,6 +173,14 @@ class Flask:
         self.template_folder = template_folder
         self._rules: List[_Rule] = []
         self.url_map = _URLMap(self._rules)
+        # Application config dictionary (subset used by freezer)
+        self.config: Dict[str, Any] = {}
+        # Root path used by flask_frozen to build URLs
+        self.root_path = os.getcwd()
+        # Minimal compatibility with Flask's url_default_functions attribute used
+        # by flask_frozen to register callbacks. Dictionary mapping blueprint
+        # names to lists of callables.
+        self.url_default_functions: Dict[str | None, List[Callable[..., None]]] = {}
 
     # ------------------------------------------------------------------
     # Routing helpers


### PR DESCRIPTION
## Summary
- note the 1px sentinel fix for navbar transparency in CHANGELOG and ISSUES_LOG
- expand flask stub so freezer import succeeds

## Testing
- `pytest tests/test_navbar_transparency.py::test_navbar_transparency -q` *(fails: AttributeError: 'Flask' object has no attribute 'test_request_context')*

------
https://chatgpt.com/codex/tasks/task_e_6854458778488323ba796660234d5e57